### PR TITLE
Improve Pipfile and setup.py to allow in-place editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,7 @@
 -   Updates the library install path to `PytaskIO` class & removes `requirements.txt` [Issue #32](https://github.com/joegasewicz/pytask-io/issues/32)
 -   Adds `Pipefile` & `Pipfile.lock` / pipenv to the project [Issue #31](https://github.com/joegasewicz/pytask-io/pull/31)
 
+**Release 0.0.5** - 2020-02-29
+-   Remove unused packages [Issue #35](https://github.com/joegasewicz/pytask-io/issues/35)
+
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 
 **Release 0.0.5** - 2020-02-29
 -   Remove unused packages [Issue #35](https://github.com/joegasewicz/pytask-io/issues/35)
+-   Improve `Pipfile` & `setup.py` to allow in-place editing using pipenv.
 
 ## Unreleased

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,4 @@ pampy = "*"
 importlib-metadata = "*"
 
 [packages]
-redis = ">=3.3.11,<4.0.0"
-dill = ">=0.3.1.1,<0.4.0.0"
-toolz = ">=0.10.0,<0.11.0"
+pytask-io = {path = ".", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c16145bcd1f7db34795491bb2573acba62cce51371c3f73d29ec9ae8f7ec4524"
+            "sha256": "755c053915e66d88ce8497d48998b6870650c0f9029b48ee21495e18c4ce028f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -18,23 +18,18 @@
             "hashes": [
                 "sha256:42d8ef819367516592a825746a18073ced42ca169ab1f5f4044134703e7a049c"
             ],
-            "index": "pypi",
             "version": "==0.3.1.1"
+        },
+        "pytask-io": {
+            "editable": true,
+            "path": "."
         },
         "redis": {
             "hashes": [
                 "sha256:0dcfb335921b88a850d461dc255ff4708294943322bd55de6cfd68972490ca1f",
                 "sha256:b205cffd05ebfd0a468db74f0eedbff8df1a7bfc47521516ade4692991bb0833"
             ],
-            "index": "pypi",
             "version": "==3.4.1"
-        },
-        "toolz": {
-            "hashes": [
-                "sha256:08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560"
-            ],
-            "index": "pypi",
-            "version": "==0.10.0"
         }
     },
     "develop": {

--- a/pytask_io/pytask_io.py
+++ b/pytask_io/pytask_io.py
@@ -5,8 +5,7 @@ Pytask IO Class
 import asyncio
 from typing import List, Callable
 import redis
-import time
-from threading import Thread, Event, currentThread#
+from threading import Thread
 from typing import Dict, Any, Union
 
 from pytask_io.task_queue import (

--- a/pytask_io/store.py
+++ b/pytask_io/store.py
@@ -1,7 +1,5 @@
 import redis
-import asyncio
 from typing import Any, Dict
-from functools import partial
 from pytask_io.logger import logger
 
 from pytask_io.utils import (
@@ -124,18 +122,6 @@ def get_uow_from_store(store, uow_key: str) -> Dict[str, Any]:
         )
     else:
         return result
-
-
-# async def _get_uow_from_store(uow_key: str) -> Dict[str, Any]:
-#     current_loop = asyncio.get_running_loop()
-#     result = await current_loop.run_in_executor(None, _store.get, uow_key)
-#     if not result:
-#         logger.error(
-#             f"[PYTASKIO ERROR]: Could not get unit of work with "
-#             f"key of {uow_key} from store."
-#         )
-#     else:
-#         return result
 
 
 async def add_uof_result_to_store(executed_uow: Any, uow_metadata: Dict[str, Any], store) -> None:

--- a/pytask_io/utils.py
+++ b/pytask_io/utils.py
@@ -1,10 +1,7 @@
 import asyncio
-import logging
 import redis
 import dill
-import json
-from toolz.functoolz import compose, curry, pipe
-from typing import List, Any, Dict, Tuple, Callable, Awaitable
+from typing import List, Any, Tuple, Callable
 from datetime import datetime
 
 
@@ -68,6 +65,7 @@ def deserialize_store_data_sync(task_data: Any):
     """
     deserialized_uow = dill.loads(task_data)
     return deserialized_uow
+
 
 def get_datetime_now():
     now = datetime.now()

--- a/pytask_io/worker.py
+++ b/pytask_io/worker.py
@@ -2,7 +2,6 @@ import asyncio
 from typing import List, Callable
 
 from pytask_io.store import add_uof_result_to_store
-from pytask_io.utils import serialize_store_data, deserialize_task
 
 tasks = []
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     description="An asynchronous Tasks Library using asyncio",
     packages=['pytask_io'],
     install_requires=[
-        'redis',
-        'dill'
+        'redis>=3.3.11,<4.0.0',
+        'dill>=0.3.1.1,<0.4.0.0',   
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
I've made a mistake in a previous PR as I treated this repo as a service, not a package.
This PR fixes that and allows in-place editing using pipenv.
I followed [requests](https://github.com/psf/requests/blob/master/Pipfile) approach.