### PR TITLE
Fix for python3.10

### DIFF
--- a/pytask_io/pytask_io.py
+++ b/pytask_io/pytask_io.py
@@ -186,7 +186,7 @@ class PyTaskIO:
         :return: None
         """
         self.main_loop = asyncio.new_event_loop()
-        self._worker_queue = asyncio.Queue(loop=self.main_loop)
+        self._worker_queue = asyncio.Queue()
         self.main_loop.create_task(client(self._worker_queue, self.queue_client, self.workers))
         self.main_loop.run_forever()
 


### PR DESCRIPTION
Fix for error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/dist-packages/pytask_io/pytask_io.py", line 189, in _run_event_loop
    self._worker_queue = asyncio.Queue(loop=self.main_loop)
  File "/usr/lib/python3.10/asyncio/queues.py", line 34, in __init__
    super().__init__(loop=loop)
  File "/usr/lib/python3.10/asyncio/mixins.py", line 17, in __init__
    raise TypeError(
TypeError: As of 3.10, the *loop* parameter was removed from Queue() since it is no longer necessary
```